### PR TITLE
Update for TF2 version 7695204 (2022-12-02)

### DIFF
--- a/addons/sourcemod/gamedata/thriller.plugin.txt
+++ b/addons/sourcemod/gamedata/thriller.plugin.txt
@@ -22,12 +22,12 @@
         {
             "Offset_ThrillerTaunt"
             {
-                "linux"         "2605"    // A2D
-                "windows"       "3101"    // C1D
+                "linux"         "2621"
+                "windows"       "3104"
             }
             "Payload_ThrillerTaunt"
             {
-                "linux"     "128"   // NEAR JNO
+                "linux"     "128"   // NEAR JO
                 "windows"   "113"   // SHORT JNO
             }
         }


### PR DESCRIPTION
Boilerplate text:

> Brings gamedata up to date with the recent TF2 release.
> 
> (Note that there may be breakages elsewhere in the plugin.  I'd suggest independently verifying that the gamedata works.)